### PR TITLE
Use default config file.

### DIFF
--- a/src/main/scala/com/joypeg/scamandrill/utils/Utils.scala
+++ b/src/main/scala/com/joypeg/scamandrill/utils/Utils.scala
@@ -5,7 +5,7 @@ import com.typesafe.config.ConfigFactory
 
 object `package` {
   lazy val config = {
-    ConfigFactory.load("application.conf")
+    ConfigFactory.load()
   }
 }
 


### PR DESCRIPTION
Hi dzsessona,

This is a nice library to use Mandrill. Thanks a lot!

I want to use default config files of typesafe config because it's also refer `application.conf` by default and occasionally use the config file by javaOptions of `-Dconfig.resource=xxx.conf` or `-Dconfig.file=yyy.conf`. Could you consider to merge this change?
